### PR TITLE
Disable custom transition animations on iOS 11 devices

### DIFF
--- a/QuipperVideoPlayer/TransitionAnimators/VideoListToPlayerTransitionAnimator.swift
+++ b/QuipperVideoPlayer/TransitionAnimators/VideoListToPlayerTransitionAnimator.swift
@@ -97,7 +97,11 @@ extension VideoListToPlayerTransitionAnimator: UIViewControllerAnimatedTransitio
 extension VideoListViewController: UIViewControllerTransitioningDelegate {
     
     func animationController(forPresented presented: UIViewController, presenting: UIViewController, source: UIViewController) -> UIViewControllerAnimatedTransitioning? {
-        return VideoListToPlayerTransitionAnimator(animationType: .present)
+        if #available(iOS 12.0, *) {
+            return VideoListToPlayerTransitionAnimator(animationType: .present)
+        } else {
+            return nil
+        }
     }
     
     func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {


### PR DESCRIPTION
There seems to be a problem when using custom transition animation
on iOS 11 devices. Will add the animatinos back once the problem
has been solved.